### PR TITLE
Add version info

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -26,6 +26,8 @@ navbar:
         - text: "RStudio Documentation"
           href: help.html#rstudio-documentation
         - text: "About"
+        - text: "Version"
+          href: help.html#quickstart-version
         - text: "Intended Use"
           href: help.html#intended-use
         - text: "Webmail Server"

--- a/help.Rmd
+++ b/help.Rmd
@@ -2,6 +2,28 @@
 title: "RStudio QuickStart - Help"
 ---
 
+<!--html_preserve-->
+<script type="text/javascript">
+function set_version() {
+    var obj = document.getElementById("quickstart-version");
+    const Http = new XMLHttpRequest();
+    const url=window.location.origin + '/version';
+    Http.open("GET", url);
+
+    // important to create this listenter _before_ we send it... #asyncprobs
+    Http.onreadystatechange=(e)=>{
+      if (Http.status == 200) {
+        obj.innerHTML = obj.innerHTML.replace('Unknown', Http.responseText);
+      }
+    }
+    Http.send();
+}
+window.onload = function() {
+  set_version()
+}
+</script>
+<!--/html_preserve-->
+
 ## Help
 
 ### Support and Feedback
@@ -23,6 +45,10 @@ You can also view a list of curated [RStudio Connect Support Documentation](http
 <hr>
 
 ## About
+
+### Version { #quickstart-version }
+
+Quickstart VM Version: Unknown
 
 ### Intended Use
 

--- a/help.Rmd
+++ b/help.Rmd
@@ -5,14 +5,14 @@ title: "RStudio QuickStart - Help"
 <!--html_preserve-->
 <script type="text/javascript">
 function set_version() {
-    var obj = document.getElementById("quickstart-version");
     const Http = new XMLHttpRequest();
     const url=window.location.origin + '/version';
     Http.open("GET", url);
 
     // important to create this listenter _before_ we send it... #asyncprobs
     Http.onreadystatechange=(e)=>{
-      if (Http.status == 200) {
+      var obj = document.getElementById("quickstart-version");
+      if (Http.status == 200 && Http.responseText != "") {
         obj.innerHTML = obj.innerHTML.replace('Unknown', Http.responseText);
       }
     }


### PR DESCRIPTION
- Add "Version" info to the About page and the header
- Add JavaScript function to dynamically populate this value on page load (using the `/version` information from within the QuickStart)


NOTE: Did not regenerate dependencies / HTML files, since these will need to be regenerated soon anyways. Is this a bad idea?